### PR TITLE
Fixes error when using "objects" command

### DIFF
--- a/vsdcli/printer.py
+++ b/vsdcli/printer.py
@@ -167,6 +167,9 @@ class Printer(object):
         """ Get object dictionnary with filtered fields
 
         """
+        if type(obj) is str:
+            return obj
+
         default_dict = obj.to_dict()
 
         if fields is None or 'ALL' in fields:


### PR DESCRIPTION
If the type is not checked, the following error appears:

Traceback (most recent call last):
  File "/usr/bin/vsd", line 9, in <module>
    load_entry_point('vspk==3.2.4', 'console_scripts', 'vsd')()
  File "build/bdist.linux-x86_64/egg/vspk/cli/cli.py", line 116, in main
  File "build/bdist.linux-x86_64/egg/vspk/cli/commands.py", line 44, in execute
    # Get the output from a shell command into a string.
  File "build/bdist.linux-x86_64/egg/vspk/cli/commands.py", line 242, in objects

  File "build/bdist.linux-x86_64/egg/vspk/cli/printer.py", line 106, in output
  File "build/bdist.linux-x86_64/egg/vspk/cli/printer.py", line 129, in json
  File "build/bdist.linux-x86_64/egg/vspk/cli/printer.py", line 171, in _object_to_dict
AttributeError: 'str' object has no attribute 'to_dict'